### PR TITLE
Add age certifications API to the wrapper

### DIFF
--- a/src/Apis/AbstractApi.php
+++ b/src/Apis/AbstractApi.php
@@ -25,7 +25,7 @@ abstract class AbstractApi
     public function __construct(HttpAdapter $adapter, ?string $locale = null, ?string $endpoint = null)
     {
         $this->adapter = $adapter;
-        $this->locale = $locale ?? static::DEFAULT_LOCALE;
+        $this->locale = $locale ?: static::DEFAULT_LOCALE;
         $this->endpoint = $endpoint ?: static::ENDPOINT;
     }
 }

--- a/src/Apis/AgeCertifications.php
+++ b/src/Apis/AgeCertifications.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace pxgamer\JustWatch\Apis;
+
+use pxgamer\JustWatch\Entities\AgeCertification as AgeCertificationEntity;
+
+final class AgeCertifications extends AbstractApi
+{
+    private const DEFAULT_COUNTRY = 'US';
+
+    /**
+     * @param  string|null  $country
+     *
+     * @return array<AgeCertificationEntity>
+     */
+    public function getMovieCertifications(?string $country = null): array
+    {
+        $query = http_build_query([
+            'country' => $country ?? self::DEFAULT_COUNTRY,
+            'object_type' => 'movie',
+        ]);
+
+        $ageCertifications = $this->adapter->get(sprintf('%s/age_certifications?%s', $this->endpoint, $query));
+        $ageCertifications = json_decode($ageCertifications, false);
+
+        return array_map(static function ($ageCertification) {
+            return new AgeCertificationEntity($ageCertification);
+        }, $ageCertifications);
+    }
+
+    /**
+     * @param  string|null  $country
+     *
+     * @return array<AgeCertificationEntity>
+     */
+    public function getTvCertifications(?string $country = null): array
+    {
+        $query = http_build_query([
+            'country' => $country ?? self::DEFAULT_COUNTRY,
+            'object_type' => 'show',
+        ]);
+
+        $ageCertifications = $this->adapter->get(sprintf('%s/age_certifications?%s', $this->endpoint, $query));
+        $ageCertifications = json_decode($ageCertifications, false);
+
+        return array_map(static function ($ageCertification) {
+            return new AgeCertificationEntity($ageCertification);
+        }, $ageCertifications);
+    }
+}

--- a/src/Entities/AgeCertification.php
+++ b/src/Entities/AgeCertification.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace pxgamer\JustWatch\Entities;
+
+final class AgeCertification extends AbstractEntity
+{
+    /** @var int */
+    public $id;
+    /** @var string */
+    public $technicalName;
+    /** @var string */
+    public $description;
+    /** @var string */
+    public $objectType;
+    /** @var string */
+    public $country;
+    /** @var int */
+    public $order;
+    /** @var string */
+    public $organization;
+}

--- a/src/JustWatch.php
+++ b/src/JustWatch.php
@@ -7,6 +7,7 @@ namespace pxgamer\JustWatch;
 use pxgamer\JustWatch\Apis\Genres;
 use pxgamer\JustWatch\Apis\Providers;
 use pxgamer\JustWatch\Adapters\HttpAdapter;
+use pxgamer\JustWatch\Apis\AgeCertifications;
 
 final class JustWatch
 {
@@ -20,6 +21,11 @@ final class JustWatch
     {
         $this->adapter = $adapter;
         $this->locale = $locale ?? 'en_US';
+    }
+
+    public function ageCertifications(): AgeCertifications
+    {
+        return new AgeCertifications($this->adapter, $this->locale);
     }
 
     public function genres(): Genres

--- a/tests/Feature/AgeCertificationsApiTest.php
+++ b/tests/Feature/AgeCertificationsApiTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace pxgamer\JustWatch\Tests\Feature;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Handler\MockHandler;
+use pxgamer\JustWatch\Adapters\HttpAdapter;
+use pxgamer\JustWatch\Apis\AgeCertifications;
+use pxgamer\JustWatch\Entities\AgeCertification as AgeCertificationEntity;
+
+final class AgeCertificationsApiTest extends TestCase
+{
+    /** @test */
+    public function itCanRetrieveAllMovieAgeCertifications(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], file_get_contents(__DIR__.'/../Resources/AgeCertifications.json')),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $adapter = new HttpAdapter($client);
+        $ageCertification = new AgeCertifications($adapter);
+        $allAgeCertifications = $ageCertification->getMovieCertifications();
+
+        $this->assertIsArray($allAgeCertifications);
+        $this->assertCount(2, $allAgeCertifications);
+        $this->assertContainsOnlyInstancesOf(AgeCertificationEntity::class, $allAgeCertifications);
+    }
+
+    /** @test */
+    public function itCanRetrieveAllTvAgeCertifications(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], file_get_contents(__DIR__.'/../Resources/AgeCertifications.json')),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $adapter = new HttpAdapter($client);
+        $ageCertification = new AgeCertifications($adapter);
+        $allAgeCertifications = $ageCertification->getTvCertifications();
+
+        $this->assertIsArray($allAgeCertifications);
+        $this->assertCount(2, $allAgeCertifications);
+        $this->assertContainsOnlyInstancesOf(AgeCertificationEntity::class, $allAgeCertifications);
+    }
+
+    /** @test */
+    public function itCanRetrieveUAgeCertification(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], file_get_contents(__DIR__.'/../Resources/AgeCertifications.json')),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $adapter = new HttpAdapter($client);
+        $ageCertifications = new AgeCertifications($adapter);
+        /** @var AgeCertificationEntity $ageCertification */
+        $ageCertification = $ageCertifications->getMovieCertifications()[0];
+
+        $this->assertInstanceOf(AgeCertificationEntity::class, $ageCertification);
+        $this->assertEquals(72, $ageCertification->id);
+        $this->assertEquals('U', $ageCertification->technicalName);
+        $this->assertStringStartsWith('All ages admitted, there is nothing', $ageCertification->description);
+        $this->assertEquals('movie', $ageCertification->objectType);
+        $this->assertEquals('GB', $ageCertification->country);
+        $this->assertEquals(1, $ageCertification->order);
+        $this->assertEquals('BBFC', $ageCertification->organization);
+    }
+
+    /** @test */
+    public function itCanRetrievePgAgeCertification(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], file_get_contents(__DIR__.'/../Resources/AgeCertifications.json')),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $adapter = new HttpAdapter($client);
+        $ageCertifications = new AgeCertifications($adapter);
+        /** @var AgeCertificationEntity $ageCertification */
+        $ageCertification = $ageCertifications->getMovieCertifications()[1];
+
+        $this->assertInstanceOf(AgeCertificationEntity::class, $ageCertification);
+        $this->assertEquals(73, $ageCertification->id);
+        $this->assertEquals('PG', $ageCertification->technicalName);
+        $this->assertStringStartsWith('All ages admitted, but certain scenes', $ageCertification->description);
+        $this->assertEquals('movie', $ageCertification->objectType);
+        $this->assertEquals('GB', $ageCertification->country);
+        $this->assertEquals(2, $ageCertification->order);
+        $this->assertEquals('BBFC', $ageCertification->organization);
+    }
+}

--- a/tests/Resources/AgeCertifications.json
+++ b/tests/Resources/AgeCertifications.json
@@ -1,0 +1,20 @@
+[
+    {
+        "id": 72,
+        "technical_name": "U",
+        "description": "All ages admitted, there is nothing unsuitable for children.",
+        "object_type": "movie",
+        "country": "GB",
+        "order": 1,
+        "organization": "BBFC"
+    },
+    {
+        "id": 73,
+        "technical_name": "PG",
+        "description": "All ages admitted, but certain scenes may be unsuitable for young children. May contain mild language and sex/drugs references. May contain moderate violence if justified by context (e.g. fantasy).",
+        "object_type": "movie",
+        "country": "GB",
+        "order": 2,
+        "organization": "BBFC"
+    }
+]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add the Age Certifications API to the package.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
